### PR TITLE
[DEV-63/FE] feat: vercel 배포 자동화 설정 (main -> production)

### DIFF
--- a/.github/workflows/deploy-frontend-main.yml
+++ b/.github/workflows/deploy-frontend-main.yml
@@ -1,0 +1,57 @@
+name: Deploy Frontend (main -> production)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+concurrency:
+  group: vercel-frontend-prod
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install deps (root)
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (frontend)
+        working-directory: frontend
+        run: pnpm lint
+
+      - name: Build (frontend)
+        working-directory: frontend
+        run: pnpm build
+
+      - name: Vercel pull (production)
+        working-directory: frontend
+        run: npx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+
+      - name: Vercel build (production)
+        working-directory: frontend
+        run: npx vercel build --prod --token=$VERCEL_TOKEN
+
+      - name: Vercel deploy (production)
+        working-directory: frontend
+        run: npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN


### PR DESCRIPTION
### 관련 이슈
#50 

### 작업한 내용

**Vercel CLI 이용한 배포 자동화 설정**
- frontend 폴더 변경 시, main 브랜치 -> Production 배포

### PR 리뷰시 참고할 사항
- 개인 레포로 fork해서 배포하지 않고, Vercel CLI를 이용하여 무료로 배포하는 방법을 테스트 중입니다.

### 참고 자료 (링크, 사진, 예시 코드 등)
