### PR TITLE
[DEV-160/FE] feat: 화면 사이즈 작은 경우 대비하여 대시보드 레이아웃 width: 1152px (w-6xl) 으로 설정

### DIFF
--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from 'react-router'
+
+export default function DashboardLayout() {
+  return (
+    <div className="mx-auto mt-7 w-6xl">
+      <Outlet />
+    </div>
+  )
+}

--- a/frontend/src/layouts/index.ts
+++ b/frontend/src/layouts/index.ts
@@ -1,2 +1,3 @@
+export { default as DashboardLayout } from './DashboardLayout'
 export { default as MobileLayout } from './MobileLayout'
 export { default as RootLayout } from './RootLayout'

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router'
-import { MobileLayout, RootLayout } from '@/layouts'
+import { DashboardLayout, MobileLayout, RootLayout } from '@/layouts'
 import {
   DashboardPage,
   RecordConfirmPage,
@@ -47,6 +47,7 @@ const router = createBrowserRouter([
     children: [
       {
         path: ROUTES.DASHBOARD,
+        Component: DashboardLayout,
         children: [
           { index: true, Component: DashboardPage },
           {


### PR DESCRIPTION
### 관련 이슈
close #217 

### 작업한 내용

화면 사이즈 작은 경우 대비하여 대시보드 레이아웃 width: 1152px (w-6xl) 으로 설정

### PR 리뷰시 참고할 사항

페어 프로그래밍으로 작성한 내용입니다.

### 참고 자료 (링크, 사진, 예시 코드 등)

대시보드 width 정하기 위해 터널링으로 13인치 맥북에서 테스트 해보고 1152px로 결정