### PR TITLE
[DEV-197/BE] feat: springdoc operation id 추가

### DIFF
--- a/backend/src/main/resources/application-swagger.yml
+++ b/backend/src/main/resources/application-swagger.yml
@@ -2,3 +2,6 @@ springdoc:
   swagger-ui:
     defaultModelsExpandDepth: 0
     operationsSorter: alpha
+    display-operation-id: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,9 +14,3 @@ spring:
 server:
   tomcat:
     uri-encoding: UTF-8
-
-springdoc:
-  swagger-ui:
-    display-operation-id: true
-  default-consumes-media-type: application/json
-  default-produces-media-type: application/json


### PR DESCRIPTION
### 관련 이슈
close #274 

### 작업한 내용
Swagger web에서 operation id 같이 표시되게 변경

### PR 리뷰시 참고할 사항
- 프론트에서 개발 편의를 위해 Swagger web에 operation id가 같이 표시되어야 합니다.

### 참고 자료 (링크, 사진, 예시 코드 등)
<img width="2840" height="1442" alt="image" src="https://github.com/user-attachments/assets/3298264a-b78d-4e53-bfc9-16ce991c6941" />

