### PR TITLE
[DEV-261/BE] refactor: Swagger의 Pageable 객체 렌더링 개선

### DIFF
--- a/backend/src/main/java/com/shyashyashya/refit/domain/interview/api/DashboardController.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/interview/api/DashboardController.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -68,7 +69,7 @@ public class DashboardController {
             """)
     @GetMapping("/interview/upcoming")
     public ResponseEntity<ApiResponse<Page<DashboardUpcomingInterviewResponse>>> getUpcomingInterviews(
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         var body = dashboardService.getUpcomingInterviews(pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -77,7 +78,7 @@ public class DashboardController {
     @Operation(summary = "대시보드에서 '내가 어렵게 느낀 질문'을 조회합니다.")
     @GetMapping("/qna-set/my/difficult")
     public ResponseEntity<ApiResponse<Page<DashboardMyDifficultQuestionResponse>>> getMyDifficultQnaSets(
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         var body = dashboardService.getMyDifficultQnaSets(pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -86,7 +87,7 @@ public class DashboardController {
     @Operation(summary = "대시보드에서 복기 대기중인 면접 리스트를 조회합니다.")
     @GetMapping("/interview/debrief-uncompleted")
     public ResponseEntity<ApiResponse<Page<DashboardDebriefIncompletedInterviewResponse>>>
-            getDebriefIncompletedInterviews(Pageable pageable) {
+            getDebriefIncompletedInterviews(@ParameterObject Pageable pageable) {
         var body = dashboardService.getDebriefIncompletedInterviews(pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/shyashyashya/refit/domain/interview/api/InterviewMyController.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/interview/api/InterviewMyController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +36,7 @@ public class InterviewMyController {
             """)
     @PostMapping("/search")
     public ResponseEntity<ApiResponse<Page<InterviewDto>>> searchInterviews(
-            @Valid @RequestBody InterviewSearchRequest request, Pageable pageable) {
+            @Valid @RequestBody InterviewSearchRequest request, @ParameterObject Pageable pageable) {
         var body = interviewService.searchMyInterviews(request, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -47,7 +48,7 @@ public class InterviewMyController {
             """)
     @GetMapping("/draft")
     public ResponseEntity<ApiResponse<Page<InterviewSimpleDto>>> getMyInterviewDrafts(
-            @RequestParam InterviewDraftType interviewDraftType, Pageable pageable) {
+            @RequestParam InterviewDraftType interviewDraftType, @ParameterObject Pageable pageable) {
         var body = interviewService.getMyInterviewDrafts(interviewDraftType, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/api/QnaSetController.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/api/QnaSetController.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +50,7 @@ public class QnaSetController {
     public ResponseEntity<ApiResponse<Page<FrequentQnaSetResponse>>> getFrequentQuestions(
             @RequestParam(required = false) Set<Long> industryIds,
             @RequestParam(required = false) Set<Long> jobCategoryIds,
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         var body = qnaSetService.getFrequentQuestions(industryIds, jobCategoryIds, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -118,7 +119,7 @@ public class QnaSetController {
     @Operation(summary = "지정한 질문 답변 세트가 스크랩 폴더에 포함되어 있는 지 여부가 포함된 스크랩 폴더 리스트를 조회합니다.")
     @GetMapping("/{qnaSetId}/scrap-folder")
     public ResponseEntity<ApiResponse<Page<QnaSetScrapFolderResponse>>> getScrapFoldersContainingQnaSet(
-            @PathVariable Long qnaSetId, Pageable pageable) {
+            @PathVariable Long qnaSetId, @ParameterObject Pageable pageable) {
         var body = qnaSetService.getMyScrapFoldersWithQnaSetContainingInfo(qnaSetId, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/api/QnaSetMyController.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/api/QnaSetMyController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +36,7 @@ public class QnaSetMyController {
             description = "나의 빈출 질문 카테고리 리스트와 각 카테고리 별 질문 개수를 질문 개수가 많은 카테고리 순으로 정렬하여 조회합니다.")
     @GetMapping("/frequent/category")
     public ResponseEntity<ApiResponse<Page<FrequentQnaSetCategoryResponse>>> getMyFrequentQnaSetCategories(
-            Pageable pageable) {
+            @ParameterObject Pageable pageable) {
         var body = qnaSetMyService.getFrequentQnaSetCategories(pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -44,7 +45,7 @@ public class QnaSetMyController {
     @Operation(summary = "나의 빈출 질문 중 특정 카테고리에 속한 질문들을 조회합니다.", description = "나의 빈출 질문 중 특정 카테고리에 속한 질문들을 조회합니다.")
     @GetMapping("/frequent/category/{categoryId}")
     public ResponseEntity<ApiResponse<Page<FrequentQnaSetCategoryQuestionResponse>>>
-            getMyFrequentQnaSetCategoryQuestions(@PathVariable Long categoryId, Pageable pageable) {
+            getMyFrequentQnaSetCategoryQuestions(@PathVariable Long categoryId, @ParameterObject Pageable pageable) {
         var body = qnaSetMyService.getFrequentQnaSetCategoryQuestions(categoryId, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -53,7 +54,7 @@ public class QnaSetMyController {
     @Operation(summary = "나의 면접 질문들을 검색합니다.", description = "나의 면접 질문들을 검색합니다. 조건을 넣지 않으면 전체 데이터를 조회합니다.")
     @PostMapping("/search")
     public ResponseEntity<ApiResponse<Page<QnaSetSearchResponse>>> searchMyQnaSet(
-            @Valid @RequestBody QnaSetSearchRequest request, Pageable pageable) {
+            @Valid @RequestBody QnaSetSearchRequest request, @ParameterObject Pageable pageable) {
         var body = qnaSetMyService.searchQnaSets(request, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/shyashyashya/refit/domain/scrapfolder/api/ScrapFolderController.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/scrapfolder/api/ScrapFolderController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +39,8 @@ public class ScrapFolderController {
             summary = "나의 스크랩 폴더 리스트를 조회합니다.",
             description = "스크랩 폴더 리스트에 '나의 어려웠던 질문' 폴더는 포함하지 않습니다. 해당 폴더의 내용은 어려웠던 질문을 조회하는 API로 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<ScrapFolderResponse>>> getMyScrapFolders(Pageable pageable) {
+    public ResponseEntity<ApiResponse<Page<ScrapFolderResponse>>> getMyScrapFolders(
+            @ParameterObject Pageable pageable) {
         var body = scrapFolderService.getMyScrapFolders(pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);
@@ -49,7 +51,7 @@ public class ScrapFolderController {
             description = "'나의 어려웠던 질문' 폴더는 포함하지 않습니다. 해당 폴더의 내용은 어려웠던 질문을 조회하는 API로 조회합니다.")
     @GetMapping("/{scrapFolderId}")
     public ResponseEntity<ApiResponse<Page<ScrapFolderQnaSetResponse>>> getQnaSetsInScrapFolder(
-            @PathVariable Long scrapFolderId, Pageable pageable) {
+            @PathVariable Long scrapFolderId, @ParameterObject Pageable pageable) {
         var body = scrapFolderService.getQnaSetsInScrapFolder(scrapFolderId, pageable);
         var response = ApiResponse.success(COMMON200, body);
         return ResponseEntity.ok(response);


### PR DESCRIPTION
### 관련 이슈
close #381 

### 작업한 내용
- Pageable을 참조하는 API에 대하여, Swagger 렌더링 시 Pageable의 각 필드가 독립적인 쿼리 파라미터로 보일 수 있도록 변경하였습니다.
  - 첫번째 사진에서 두번째 사진처럼 렌더링되도록 수정

### 참고 자료 (링크, 사진, 예시 코드 등)
<img width="2818" height="1904" alt="image" src="https://github.com/user-attachments/assets/76337274-40c6-4fd4-82f2-7df839d80a8f" />
<img width="2840" height="1668" alt="image" src="https://github.com/user-attachments/assets/6d33a3ca-5d65-4e5b-bdb1-db87987249e2" />
