### PR TITLE
[DEV-251/FE] fix: 텍스트 인식 불가능한 PDF 업로드시 UI 깨짐 이슈 수정

### DIFF
--- a/frontend/src/features/record/link/components/pdf-section/PdfPage.tsx
+++ b/frontend/src/features/record/link/components/pdf-section/PdfPage.tsx
@@ -67,6 +67,7 @@ export function PdfPage({ pdf, pageNumber, containerSize }: PdfPageProps) {
       if (cancelled) return
       const hasText = textContent.items.some((item) => 'str' in item && item.str.trim().length > 0)
       setHasSelectableText(hasText)
+      if (!hasText) return
 
       textLayerInstance = new TextLayer({
         container: textLayerRef.current,

--- a/frontend/src/styles/pdf-text-layer.css
+++ b/frontend/src/styles/pdf-text-layer.css
@@ -76,15 +76,3 @@
 .textLayer.selecting .endOfContent {
   top: 0;
 }
-
-/* pdf.js 내부 텍스트 측정용 캔버스가 화면에 노출되지 않도록 숨김 처리 */
-.hiddenCanvasElement {
-  position: absolute;
-  top: 0;
-  left: -100000px;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  pointer-events: none;
-  z-index: -1;
-}


### PR DESCRIPTION
### 관련 이슈
close #362 

### 작업한 내용
- 텍스트 인식 불가능한 PDF 업로드 시, 하단에 검정 영역이 생기는 이슈가 있었습니다.
  - 원인: 텍스트가 없는 PDF의 경우, hiddenCanvasElement에 `aspect-ratio: auto 0 / 0;` 규칙이 적용되지 않았음
  - 해결 1. pdf.js 내부 텍스트 측정용 캔버스가 hiddenCanvasElement를 숨김 처리하는 CSS 추가했었다가,
  - 해결 2. textContent.itemes가 없으면 TextLayer를 렌더하지 않는 방식으로 처리하였습니다.
 
- textContent.items가 없으면 PDF 뷰어 오른쪽 하단에 안내 메세지 띄워두었습니다.
<img width="495" height="771" alt="스크린샷 2026-02-18 오전 4 18 50" src="https://github.com/user-attachments/assets/9280cdfe-7fd0-4a10-a1d1-1c074aed5a8c" />


---
### 원인 정리

**[ 문제 상황 ]**

스캔본(텍스트 추출이 불가능한) PDF 업로드 시 페이지 하단에 검정 영역이 추가로 생기는 현상 발생했음.

**[ 원인 분석 ]**

pdf.js는 텍스트 위치 계산을 위해 내부적으로
hiddenCanvasElement라는 <canvas>를 document.body 하단에 생성함.
이 캔버스는 화면에 보이지 않아야 하는 측정용 요소임.


**[ 1. width/height 문제는 아니었음 ]**

초기에는 해당 캔버스의 width/height 속성이 적용되지 않은 것으로 의심했으나,
<img width="465" height="89" alt="스크린샷 2026-02-18 오후 12 02 46" src="https://github.com/user-attachments/assets/21426d9a-fef9-47d3-b35f-fda533c8dda9" />

확인 결과 항상 0으로 정상 세팅되어 있었음. 즉, 속성값 문제는 아니었음.

**[ 2. intrinsic size(기본 크기) 활성화 - 실제 원인 ]**

`<canvas>`는 replaced element라서
CSS에서 명확히 크기를 지정하지 않으면 브라우저 기본 크기(300×150)로 레이아웃에 참여함.

**2-1. 텍스트가 인식되는 PDF의 경우:**
<img width="536" height="339" alt="스크린샷 2026-02-18 오후 12 02 31" src="https://github.com/user-attachments/assets/187c4344-be53-4868-98b6-585635f85247" />

- DevTools 상에서 aspect-ratio: auto 0 / 0 (속성 스타일) 계산 결과가 적용되어 있었음
- 이 값 때문에 intrinsic size가 무력화되었음
- 결과적으로 hidden canvas가 화면 공간을 차지하지 않았음

**2-2. 텍스트가 없는 PDF의 경우:**
<img width="536" height="339" alt="스크린샷 2026-02-18 오후 12 02 36" src="https://github.com/user-attachments/assets/e0891a76-fc7f-4567-9f20-9d709751021f" />

- 위 aspect-ratio 계산 결과가 적용되지 않았음
- 브라우저 기본 intrinsic size(300×150)가 그대로 적용되었음
- 해당 캔버스가 body 하단에서 실제 크기를 가지며 노출되고, 검정 영역처럼 보였음

**[ 왜 텍스트 유무에 따라 달라졌는가? ]**

텍스트가 있는 경우에는 TextLayer가 정상적으로 동작하면서
브라우저가 해당 캔버스를 “0 비율”로 계산했음.

텍스트가 없는 경우에는 TextLayer가 실질적으로 동작하지 않거나 조기 종료되면서
해당 계산이 적용되지 않았고, 기본 intrinsic size가 활성화되었음.

즉, hiddenCanvasElement는 항상 생성되지만
브라우저의 레이아웃 계산 결과가 달라지면서 화면 노출 여부가 갈렸던 것임.

**[ 해결 방법 ]**
텍스트 추출 결과가 없는 경우, TextLayer 렌더 자체를 스킵하도록 수정했음.
→ hidden canvas 생성 경로 차단
→ intrinsic size 활성화 상황 방지
→ 하단 검정 영역 문제 해결

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)
