### PR TITLE
[DEV-307/FE] feat: PDF 확대, 축소 기능 추가

### DIFF
--- a/frontend/src/features/record/link/components/pdf-section/PdfNavigation.tsx
+++ b/frontend/src/features/record/link/components/pdf-section/PdfNavigation.tsx
@@ -1,27 +1,68 @@
+import type { ReactNode } from 'react'
 import { CaretUpIcon } from '@/designs/assets'
 import { Button } from '@/designs/components'
+
+const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
 
 type PdfNavigationProps = {
   currentPage: number
   totalPages: number
   onPageChange: (page: number) => void
+  zoom: number
+  onZoomChange: (zoom: number) => void
+  actions?: ReactNode
 }
 
-export function PdfNavigation({ currentPage, totalPages, onPageChange }: PdfNavigationProps) {
+export function PdfNavigation({
+  currentPage,
+  totalPages,
+  onPageChange,
+  zoom,
+  onZoomChange,
+  actions,
+}: PdfNavigationProps) {
   const goToPrev = () => onPageChange(Math.max(1, currentPage - 1))
   const goToNext = () => onPageChange(Math.min(totalPages, currentPage + 1))
 
+  const currentStepIndex = ZOOM_STEPS.findIndex((s) => s >= zoom)
+  const zoomIn = () => {
+    const nextIndex = Math.min(ZOOM_STEPS.length - 1, currentStepIndex + 1)
+    onZoomChange(ZOOM_STEPS[nextIndex])
+  }
+  const zoomOut = () => {
+    const prevIndex = Math.max(0, (currentStepIndex === -1 ? ZOOM_STEPS.length : currentStepIndex) - 1)
+    onZoomChange(ZOOM_STEPS[prevIndex])
+  }
+  const resetZoom = () => onZoomChange(1)
+
   return (
-    <div className="flex shrink-0 items-center justify-center gap-4 py-3">
-      <Button size="xs" onClick={goToPrev} disabled={currentPage <= 1}>
-        <CaretUpIcon className="rotate-270" />
-      </Button>
-      <span className="body-s-regular text-gray-500">
-        {currentPage} / {totalPages}
-      </span>
-      <Button size="xs" onClick={goToNext} disabled={currentPage >= totalPages}>
-        <CaretUpIcon className="rotate-90" />
-      </Button>
+    <div className="grid shrink-0 grid-cols-[1fr_auto_1fr] items-center py-3">
+      <div />
+      <div className="flex items-center gap-4">
+        <Button size="xs" onClick={goToPrev} disabled={currentPage <= 1}>
+          <CaretUpIcon className="rotate-270" />
+        </Button>
+        <span className="body-s-regular text-gray-500">
+          {currentPage} / {totalPages}
+        </span>
+        <Button size="xs" onClick={goToNext} disabled={currentPage >= totalPages}>
+          <CaretUpIcon className="rotate-90" />
+        </Button>
+      </div>
+      <div className="flex items-center justify-end gap-3">
+        <div className="flex items-center gap-2">
+          <Button size="xs" onClick={zoomOut} disabled={zoom <= ZOOM_STEPS[0]}>
+            -
+          </Button>
+          <Button size="xs" onClick={resetZoom} disabled={zoom === 1}>
+            {Math.round(zoom * 100)}%
+          </Button>
+          <Button size="xs" onClick={zoomIn} disabled={zoom >= ZOOM_STEPS[ZOOM_STEPS.length - 1]}>
+            +
+          </Button>
+        </div>
+        {actions}
+      </div>
     </div>
   )
 }

--- a/frontend/src/features/record/link/components/pdf-section/PdfViewer.tsx
+++ b/frontend/src/features/record/link/components/pdf-section/PdfViewer.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
+import { Button } from '@/designs/components'
 import { useHighlightContext } from '@/features/record/link/contexts'
 import { PdfNavigation } from './PdfNavigation'
 import { PdfPage } from './PdfPage'
@@ -7,9 +8,19 @@ import { usePdfLoader } from './usePdfLoader'
 
 type PdfViewerProps = {
   pdfUrl: string
+  onRemovePdf?: () => void
+  isPdfBusy?: boolean
+  zoom: number
+  onZoomChange: (zoom: number) => void
 }
 
-export function PdfViewer({ pdfUrl }: PdfViewerProps) {
+export function PdfViewer({
+  pdfUrl,
+  onRemovePdf,
+  isPdfBusy,
+  zoom,
+  onZoomChange,
+}: PdfViewerProps) {
   const { pdf, isLoading, error } = usePdfLoader(pdfUrl)
   const [selectedPage, setSelectedPage] = useState<number | null>(null)
   const viewerRef = useRef<HTMLDivElement>(null)
@@ -38,11 +49,26 @@ export function PdfViewer({ pdfUrl }: PdfViewerProps) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {pdf && <PdfNavigation currentPage={currentPage} totalPages={totalPages} onPageChange={setSelectedPage} />}
+      {pdf && (
+        <PdfNavigation
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setSelectedPage}
+          zoom={zoom}
+          onZoomChange={onZoomChange}
+          actions={
+            onRemovePdf && (
+              <Button variant="outline-gray-100" onClick={onRemovePdf} size="xs" disabled={isPdfBusy}>
+                업로드 해제
+              </Button>
+            )
+          }
+        />
+      )}
       <div ref={viewerRef} className="relative min-h-0 flex-1 overflow-hidden">
         {isLoading && <p className="body-m-regular py-10 text-center text-gray-400">PDF 로딩 중...</p>}
         {error && <p className="body-m-regular py-10 text-center text-red-400">{error}</p>}
-        {isReady && <PdfPage pdf={pdf} pageNumber={currentPage} containerSize={containerSize} />}
+        {isReady && <PdfPage pdf={pdf} pageNumber={currentPage} containerSize={containerSize} zoom={zoom} />}
       </div>
     </div>
   )

--- a/frontend/src/features/retro/_common/components/pdf-panel/RetroPdfPage.tsx
+++ b/frontend/src/features/retro/_common/components/pdf-panel/RetroPdfPage.tsx
@@ -12,9 +12,10 @@ type RetroPdfPageProps = {
   pageNumber: number
   containerSize: ContainerSize
   savedRects: SavedRect[]
+  zoom: number
 }
 
-export function RetroPdfPage({ pdf, pageNumber, containerSize, savedRects }: RetroPdfPageProps) {
+export function RetroPdfPage({ pdf, pageNumber, containerSize, savedRects, zoom }: RetroPdfPageProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const textLayerRef = useRef<HTMLDivElement>(null)
@@ -32,7 +33,8 @@ export function RetroPdfPage({ pdf, pageNumber, containerSize, savedRects }: Ret
 
       const devicePixelRatio = window.devicePixelRatio || 1
       const defaultViewport = page.getViewport({ scale: 1 })
-      const scale = Math.min(containerSize.height / defaultViewport.height, containerSize.width / defaultViewport.width)
+      const baseScale = Math.min(containerSize.height / defaultViewport.height, containerSize.width / defaultViewport.width)
+      const scale = baseScale * zoom
 
       const renderViewport = page.getViewport({ scale: scale * devicePixelRatio })
       const displayViewport = page.getViewport({ scale })
@@ -72,13 +74,13 @@ export function RetroPdfPage({ pdf, pageNumber, containerSize, savedRects }: Ret
       renderTask?.cancel()
       textLayerInstance?.cancel()
     }
-  }, [pdf, pageNumber, containerSize])
+  }, [pdf, pageNumber, containerSize, zoom])
 
   const pageRects = savedRects.filter((rect) => rect.pageNumber === pageNumber)
 
   return (
-    <div ref={containerRef} className="absolute inset-0 flex items-center justify-center">
-      <div ref={pdfContentRef} className="relative overflow-hidden bg-white">
+    <div ref={containerRef} className="absolute inset-0 flex overflow-auto">
+      <div ref={pdfContentRef} className="relative m-auto shrink-0 overflow-hidden bg-white">
         <canvas ref={canvasRef} className="block bg-white" />
         <div ref={textLayerRef} className="textLayer absolute inset-0" />
         <HighlightLayer savedRects={pageRects} pendingRects={[]} />

--- a/frontend/src/features/retro/_common/components/pdf-panel/RetroPdfPanel.tsx
+++ b/frontend/src/features/retro/_common/components/pdf-panel/RetroPdfPanel.tsx
@@ -18,6 +18,7 @@ type RetroPdfPanelProps = {
 export function RetroPdfPanel({ interviewId, hasPdf: initialHasPdf, qnaSetIds }: RetroPdfPanelProps) {
   const [hasPdf, setHasPdf] = useState(initialHasPdf)
   const [selectedPage, setSelectedPage] = useState<number | null>(null)
+  const [zoom, setZoom] = useState(1)
   const viewerRef = useRef<HTMLDivElement>(null)
   const containerSize = useContainerSize(viewerRef)
 
@@ -85,7 +86,15 @@ export function RetroPdfPanel({ interviewId, hasPdf: initialHasPdf, qnaSetIds }:
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-gray-100 p-6">
-      {pdf && <PdfNavigation currentPage={currentPage} totalPages={totalPages} onPageChange={setSelectedPage} />}
+      {pdf && (
+        <PdfNavigation
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setSelectedPage}
+          zoom={zoom}
+          onZoomChange={setZoom}
+        />
+      )}
       <div ref={viewerRef} className="relative min-h-0 flex-1 overflow-hidden">
         {isLoading && (
           <div className="flex h-full items-center justify-center">
@@ -94,7 +103,13 @@ export function RetroPdfPanel({ interviewId, hasPdf: initialHasPdf, qnaSetIds }:
         )}
         {hasError && <p className="body-m-regular py-10 text-center text-red-400">PDF를 불러오는 데 실패했습니다.</p>}
         {isReady && (
-          <RetroPdfPage pdf={pdf} pageNumber={currentPage} containerSize={containerSize} savedRects={savedRects} />
+          <RetroPdfPage
+            pdf={pdf}
+            pageNumber={currentPage}
+            containerSize={containerSize}
+            savedRects={savedRects}
+            zoom={zoom}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
### 관련 이슈
close #307 

### 작업한 내용

-  getViewport({scale})을 이용하여 PDF 확대, 축소하는 기능을 추가하였습니다.
```
const scale = baseScale * zoom
const renderViewport = page.getViewport({ scale: scale * devicePixelRatio })
const displayViewport = page.getViewport({ scale })
``` 
- 가능한 zoom 정도는 `[0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]배` 로 설정해두었습니다.

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)
- PDF가 사용되는 자소서 연결, 회고, 회고 상세에서 동일하게 동작합니다.

https://github.com/user-attachments/assets/a7e2b9f7-fd03-4ad2-b1ec-0658ef576b97

