### PR TITLE
[DEV-362/FE] feat: convertResult API에 throwOnError 추가

### DIFF
--- a/frontend/src/features/record/confirm/hooks/useRecordConfirmConvertGate.ts
+++ b/frontend/src/features/record/confirm/hooks/useRecordConfirmConvertGate.ts
@@ -1,5 +1,6 @@
 import { useWaitConvertResult } from '@/apis'
 import { getApiErrorCode } from '@/features/_common/utils/error'
+import { shouldThrowInterviewRouteError } from '@/routes/interviewErrorRoute'
 
 const CONVERT_PENDING_ERROR_CODE = 'INTERVIEW_CONVERTING_STATUS_IS_PENDING'
 const CONVERT_IN_PROGRESS_ERROR_CODE = 'INTERVIEW_CONVERTING_IN_PROGRESS'
@@ -15,7 +16,7 @@ type UseRecordConfirmConvertGateOptions = {
 export function useRecordConfirmConvertGate({ interviewId }: UseRecordConfirmConvertGateOptions) {
   const { data, error, isPending, isError, refetch } = useWaitConvertResult(interviewId, {
     query: {
-      retry: false,
+      throwOnError: shouldThrowInterviewRouteError,
       refetchInterval: (query) => {
         const errorCode = getApiErrorCode(query.state.error)
         if (errorCode === CONVERT_PENDING_ERROR_CODE || errorCode === CONVERT_IN_PROGRESS_ERROR_CODE) {


### PR DESCRIPTION
### 관련 이슈
close #567 

### 작업한 내용
- convertResult API도 개별 인터뷰에 대해 조회하는 API인데, suspense가 안 걸려있어 직접 throwOnError 추가해두었습니다!

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)

https://github.com/user-attachments/assets/f68db248-2ef7-400c-8793-7abbc31dd8d5

