### PR TITLE
[DEV-362/FE] fix: CONVERT_PENDING_ERROR_CODE는 polling이 아닌 record 페이지로 이동시키는 에러로 처리

### DIFF
--- a/frontend/src/features/record/confirm/hooks/useRecordConfirmConvertGate.ts
+++ b/frontend/src/features/record/confirm/hooks/useRecordConfirmConvertGate.ts
@@ -19,7 +19,7 @@ export function useRecordConfirmConvertGate({ interviewId }: UseRecordConfirmCon
       throwOnError: shouldThrowInterviewRouteError,
       refetchInterval: (query) => {
         const errorCode = getApiErrorCode(query.state.error)
-        if (errorCode === CONVERT_PENDING_ERROR_CODE || errorCode === CONVERT_IN_PROGRESS_ERROR_CODE) {
+        if (errorCode === CONVERT_IN_PROGRESS_ERROR_CODE) {
           return REFETCH_INTERVAL_MS
         }
         return false
@@ -29,9 +29,8 @@ export function useRecordConfirmConvertGate({ interviewId }: UseRecordConfirmCon
 
   const convertStatus = data?.result?.convertStatus
   const errorCode = getApiErrorCode(error)
-  const isPollingByErrorCode = errorCode === CONVERT_PENDING_ERROR_CODE || errorCode === CONVERT_IN_PROGRESS_ERROR_CODE
-  const isConvertFailed = errorCode === CONVERT_FAILED_ERROR_CODE
-  const isPolling = isPending || isPollingByErrorCode
+  const isPolling = isPending || errorCode === CONVERT_IN_PROGRESS_ERROR_CODE
+  const isConvertFailed = errorCode === CONVERT_FAILED_ERROR_CODE || errorCode === CONVERT_PENDING_ERROR_CODE
 
   const state: ConvertGateState = (() => {
     if (isPolling) return 'loading'

--- a/frontend/src/pages/record/confirm/page.tsx
+++ b/frontend/src/pages/record/confirm/page.tsx
@@ -65,7 +65,7 @@ export default function RecordConfirmPage() {
         description={
           failureCode === CONVERT_FAILED_ERROR_CODE
             ? '기록 화면으로 돌아가 내용을 확인한 뒤 다시 시도해 주세요.'
-            : '변환을 진행할 수 없는 상태예요. 기록 화면으로 이동할게요.'
+            : '변환을 진행할 수 없는 상태예요.\n기록 화면으로 이동할게요.'
         }
         okText="확인"
         okButtonVariant="fill-gray-800"


### PR DESCRIPTION
### 관련 이슈
close #567 

### 작업한 내용
- CONVERT_PENDING_ERROR_CODE는 polling이 아닌 record 페이지로 이동시키는 에러로 처리

### PR 리뷰시 참고할 사항

- 해당 에러가 발생하는 상황이 '기록전' '기록중'인 상태에서 confirm 에 접근하는 경우라,
  -> failed 상태로 간주하고 컨펌 모달 + record 페이지로 이동시켜두었습니다.

### 참고 자료 (링크, 사진, 예시 코드 등)

<img width="1157" height="869" alt="image" src="https://github.com/user-attachments/assets/63dfec04-61cd-43c0-b507-f8544ac3580d" />
