### PR TITLE
[DEV-363/FE] feat: pdf 폰트 지원 설정 변경

### DIFF
--- a/frontend/src/features/record/link/components/pdf-section/usePdfLoader.ts
+++ b/frontend/src/features/record/link/components/pdf-section/usePdfLoader.ts
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react'
 import * as pdfjsLib from 'pdfjs-dist'
 import type { PDFDocumentProxy } from 'pdfjs-dist'
-
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString()
+
+const PDFJS_CDN_BASE = 'https://unpkg.com/pdfjs-dist@5.4.530'
+const STANDARD_FONT_DATA_URL = `${PDFJS_CDN_BASE}/standard_fonts/`
+const CMAP_URL = `${PDFJS_CDN_BASE}/cmaps/`
 
 type PdfLoadState = {
   pdf: PDFDocumentProxy | null
@@ -26,7 +29,13 @@ export function usePdfLoader(pdfUrl: string): PdfLoadState {
       setState({ pdf: null, isLoading: true, error: null })
 
       try {
-        const doc = await pdfjsLib.getDocument(pdfUrl).promise
+        const doc = await pdfjsLib.getDocument({
+          url: pdfUrl,
+          useSystemFonts: true,
+          standardFontDataUrl: STANDARD_FONT_DATA_URL,
+          cMapUrl: CMAP_URL,
+          cMapPacked: true,
+        }).promise
         if (!cancelled) {
           setState({ pdf: doc, isLoading: false, error: null })
         }


### PR DESCRIPTION
### 관련 이슈
close #571 

### 작업한 내용

PDF 폰트 깨지는 이슈를 해결하기 위해 pdfjs getDocument 메서드에 폰트 설정 속성을 추가해주었습니다. 

- useSystemFonts: true
: PDF에 임베딩되지 않은 폰트가 있을 때, 브라우저/OS에 설치된 시스템 폰트로 대체
 이게 없으면 pdfjs 기본 내장 폰트만 사용 → 한글 등 비라틴 폰트가 깨질 수 있음

- standardFontDataUrl
: PDF 표준 14 폰트(Helvetica, Times-Roman, Courier 등)의 메트릭/데이터 파일 경로
  이 폰트들이 PDF에 임베딩 안 되어 있을 때 여기서 가져옴
  없으면 translateFont failed 경고 발생

- cMapUrl
: CMap(Character Map) 파일 경로. CJK(한중일) 폰트의 문자 코드 → 유니코드 매핑 테이블
  한글 PDF에서 이 매핑이 없으면 텍스트 추출/렌더링이 깨짐
  이전에 나왔던 "Ensure that the cMapUrl and cMapPacked API parameters are provided." 경고의 원인

- cMapPacked: true
: CMap 파일이 압축(binary compact) 포맷인지 여부
  unpkg/npm에 배포된 pdfjs-dist의 cmaps는 packed 포맷이라 true 필수

한글 PDF 렌더링 + 텍스트 선택이 제대로 동작하려면 cMapUrl + cMapPacked이 핵심이고,
standardFontDataUrl + useSystemFonts는 임베딩 안 된 폰트 fallback을 위한 것입니다.

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)
이전에 폰트 이슈로 TextLayer가 인식되지 않던 PDF도 잘 불러와집니다.

<img width="500" height="783" alt="image" src="https://github.com/user-attachments/assets/b1f3bc96-62b3-483e-a3ab-d662e69a6f4d" />
