### PR TITLE
[DEV-368/BE] fix: 배치에서 카테고리 재생성시 카테고리 임베딩 벡터 삭제 로직 추가

### DIFF
--- a/backend/src/main/java/com/shyashyashya/refit/batch/service/QuestionCategoryBatchService.java
+++ b/backend/src/main/java/com/shyashyashya/refit/batch/service/QuestionCategoryBatchService.java
@@ -77,6 +77,11 @@ public class QuestionCategoryBatchService {
         }
 
         log.info("[createCategories] 6. QnaSet 이 분류되지 않은 카테고리 삭제");
+        List<Long> notEmptyCategoryIds = qnaSetCategoryRepository.findAllNotEmptyCategoryIds();
+        categoryVectorRepository
+                .findAll()
+                .filter(document -> !notEmptyCategoryIds.contains(document.getId()))
+                .forEach(document -> categoryVectorRepository.deleteById(document.getId()));
         qnaSetCategoryRepository.deleteEmptyCategory();
     }
 }

--- a/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/repository/QnaSetCategoryRepository.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/repository/QnaSetCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.shyashyashya.refit.domain.qnaset.repository;
 
 import com.shyashyashya.refit.domain.qnaset.model.QnaSetCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,15 @@ public interface QnaSetCategoryRepository extends JpaRepository<QnaSetCategory, 
     """)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     int deleteEmptyCategory();
+
+    @Query("""
+        SELECT c.id
+          FROM QnaSetCategory c
+         WHERE EXISTS (
+            SELECT 1
+              FROM QnaSet q
+             WHERE q.qnaSetCategory = c
+        )
+    """)
+    List<Long> findAllNotEmptyCategoryIds();
 }


### PR DESCRIPTION
### 관련 이슈
close #580 

### 작업한 내용
- 배치 작업 후, 카테고리를 삭제할 때 질답이 매핑되지 않은 카테고리 임베딩 벡터도 함께 삭제하도록 로직을 작성했습니다.

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)
