### PR TITLE
[DEV-381/BE] fix: 임베딩 생성이 100단위 요청일 때 LLM 에러 발생 상황 대응

### DIFF
--- a/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/event/QuestionBatchEmbeddingEventHandler.java
+++ b/backend/src/main/java/com/shyashyashya/refit/domain/qnaset/event/QuestionBatchEmbeddingEventHandler.java
@@ -92,14 +92,16 @@ public class QuestionBatchEmbeddingEventHandler {
             }
         }
 
-        var requests = new GeminiBatchEmbeddingRequest(sendQnaSets.stream()
-                .map(qnaSet -> GeminiBatchEmbeddingRequest.GeminiEmbeddingRequest.of(
-                        qnaSet.getQuestionText(),
-                        GeminiEmbeddingRequest.TaskType.SEMANTIC_SIMILARITY,
-                        outputDimensionality))
-                .toList());
-        embeddings.addAll(geminiClient.sendAsyncBatchEmbeddingRequest(requests).join().embeddings().stream()
-                .toList());
+        if (!qnaSets.isEmpty()) {
+            var requests = new GeminiBatchEmbeddingRequest(sendQnaSets.stream()
+                    .map(qnaSet -> GeminiBatchEmbeddingRequest.GeminiEmbeddingRequest.of(
+                            qnaSet.getQuestionText(),
+                            GeminiEmbeddingRequest.TaskType.SEMANTIC_SIMILARITY,
+                            outputDimensionality))
+                    .toList());
+            embeddings.addAll(geminiClient.sendAsyncBatchEmbeddingRequest(requests).join().embeddings().stream()
+                    .toList());
+        }
 
         return embeddings.stream()
                 .map(GeminiBatchEmbeddingResponse.Embedding::values)


### PR DESCRIPTION
### 관련 이슈
close #612 

### 작업한 내용
- 임베딩 생성이 100 단위 요청일 때, LLM 으로 빈 임베딩 배치 생성 요청이 나가는 문제를 수정하였습니다.

### PR 리뷰시 참고할 사항

### 참고 자료 (링크, 사진, 예시 코드 등)
